### PR TITLE
Remove my.HA buttons from generated README

### DIFF
--- a/hedgedoc/.README.j2
+++ b/hedgedoc/.README.j2
@@ -9,10 +9,6 @@
 
 _The best platform to write and share markdown._
 
-[![Open your Home Assistant instance and show the add add-on repository dialog
-with a specific repository URL pre-filled.][add-repo-shield]][add-repo]
-[![Open your Home Assistant instance and show the dashboard of a Supervisor add-on.][add-addon-shield]][add-addon]
-
 {% set repository = namespace(url='https%3A//github.com/mdegat01/hassio-addons', slug='39bd2704') %}
 {% if channel == "edge" %}
 {% set repository.url = repository.url + '-edge' %}


### PR DESCRIPTION
Generated readme shouldn't have my.home-assistant links since its shown inside HA already.