### PR TITLE
Switch config from `mysql_*` to `remote_mysql_*`

### DIFF
--- a/hedgedoc/config.json
+++ b/hedgedoc/config.json
@@ -36,11 +36,11 @@
       "session_secret": "password?",
       "session_days": "int(1,)?"
     },
-    "mysql_host": "str?",
-    "mysql_port": "port?",
-    "mysql_username": "str?",
-    "mysql_password": "password?",
-    "mysql_database": "str?",
+    "remote_mysql_host": "str?",
+    "remote_mysql_port": "port?",
+    "remote_mysql_username": "str?",
+    "remote_mysql_password": "password?",
+    "remote_mysql_database": "str?",
     "reset_database": "bool?",
     "env_vars": [
       {

--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -97,13 +97,15 @@ symlinks=( \
 )
 for i in "${symlinks[@]}"; do
     # if config file is present just remove container one and symlink
-    [[ -e "$i" && ! -L "$i" && -e "${data_dir}/$(basename "$i")" ]] && \
+    if [[ -e "$i" && ! -L "$i" && -e "${data_dir}/$(basename "$i")" ]]; then
         rm -Rf "$i" && \
         ln -s "${data_dir}/$(basename "$i")" "$i"
+    fi
     # if config file is not present move it before symlinking
-    [[ -e "$i" && ! -L "$i" ]] && \
+    if [[ -e "$i" && ! -L "$i" ]]; then
         mv "$i" "${data_dir}/$(basename "$i")" && \
         ln -s "${data_dir}/$(basename "$i")" "$i"
+    fi
 done
 
 


### PR DESCRIPTION
Going for consistency with other available addons such as [bookstack](https://github.com/hassio-addons/addon-bookstack). Using the DB with a remote DB option is a common pattern for both so using the same `remote_mysql_*` config options.