### PR TITLE
Remote DB test had incorrect nc path

### DIFF
--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -124,7 +124,7 @@ if bashio::config.exists 'remote_mysql_host'; then
 
     # Wait until db is available.
     for _ in $(seq 1 30); do
-        if /bin/nc -w1 "${host}" "${port}" > /dev/null 2>&1; then
+        if nc -w1 "${host}" "${port}" > /dev/null 2>&1; then
             break
         fi
         sleep 1


### PR DESCRIPTION
Test for checking if remote DB was online was looking for `nc` in wrong place.