### PR TITLE
Add option for disabling email registration

### DIFF
--- a/hedgedoc/config.json
+++ b/hedgedoc/config.json
@@ -36,7 +36,8 @@
       "use_ssl": "bool?",
       "add_port": "bool?",
       "session_secret": "password?",
-      "session_days": "int(1,)?"
+      "session_days": "int(1,)?",
+      "allow_email_registration": "bool?"
     },
     "remote_mysql_host": "str?",
     "remote_mysql_port": "port?",

--- a/hedgedoc/rootfs/etc/services.d/hedgedoc/run
+++ b/hedgedoc/rootfs/etc/services.d/hedgedoc/run
@@ -72,6 +72,12 @@ if bashio::config.exists 'access.session_days'; then
     export "CMD_SESSION_LIFE=$(( days * 86400000 ))"
 fi
 
+# Disable email registration if option is set to false (allowed by default)
+if bashio::config.false 'access.allow_email_registration'; then
+    bashio::log.info "Disabling email registration."
+    export CMD_ALLOW_EMAIL_REGISTER=false
+fi
+
 # Set log level
 case "$(bashio::config 'log_level')" in \
     debug)	    log_level='debug' && export DEBUG=true ;; \


### PR DESCRIPTION
Add `access.allow_email_registration` so users can easily disable email registration once they have registered everyone they want to have access and prevent unwanted public signups.