### PR TITLE
Don't log secrets from env vars

### DIFF
--- a/hedgedoc/DOCS.md
+++ b/hedgedoc/DOCS.md
@@ -161,6 +161,16 @@ USE AT YOUR OWN RISK!_
 These are case sensitive and any items set by specific configuration will take
 precedence (you can see those [here][run]).
 
+The only exception is `CMD_HSTS_ENABLE`. That is set to `false` before `env_vars`
+are processed specifically so you can choose to turn it back on if you want. Setting
+the HSTS header causes issues if you use the same domain for multiple applications
+and not all use SSL so it is disabled by default to prevent surprise errors.
+
+If you do enable HSTS HedgeDoc also sets `includeSubdomains` and `preload` by default.
+`preload` in particular can cause browsers to add your site to a public list that
+takes months to get off. Would recommend reading up on [preload][hsts-preload]
+before enabling it.
+
 #### Sub-option: `name`
 
 The name of the environment variable to set.
@@ -239,6 +249,7 @@ SOFTWARE.
 [forum]: https://community.home-assistant.io?u=CentralCommand
 [hedgedoc]: https://hedgedoc.org/
 [hedgedoc-docs]: https://docs.hedgedoc.org/
+[hsts-preload]: https://hstspreload.org/
 [issue]: https://github.com/mdegat01/addon-loki/issues
 [mdegat01]: https://github.com/mdegat01
 [releases]: https://github.com/mdegat01/addon-loki/releases

--- a/hedgedoc/rootfs/etc/services.d/hedgedoc/run
+++ b/hedgedoc/rootfs/etc/services.d/hedgedoc/run
@@ -18,17 +18,16 @@ database=hedgedoc
 # If user uses the same URL for multiple apps returning this can break things
 export CMD_HSTS_ENABLE=false
 
-# Changing this default as well because returning this value can cause browsers
-# to add your site to a list that takes months to get off. Users should get to
-# decide if they want this or not
-# See https://hstspreload.org/ for more info
-export CMD_HSTS_PRELOAD=false
-
+# --- LOAD ENV_VARS ---
 # Load user's custom environment variables
 for var in $(bashio::config 'env_vars|keys'); do
     name=$(bashio::config "env_vars[${var}].name")
     value=$(bashio::config "env_vars[${var}].value")
-    bashio::log.info "Setting ${name} to ${value}"
+    if [[ ${name} =~ SECRET ]]; then
+        bashio::log.info "Setting ${name} to ******"
+    else
+        bashio::log.info "Setting ${name} to ${value}"
+    fi
     export "${name}=${value}"
 done
 


### PR DESCRIPTION
If the environmental variable has `SECRET` in its name, don't log its value.

Also include HSTS info in docs to make it more clear what's going on for people.