### PR TITLE
Enable all log levels and map to HedgeDoc

### DIFF
--- a/hedgedoc/config.json
+++ b/hedgedoc/config.json
@@ -51,6 +51,6 @@
         "value": "str"
       }
     ],
-    "log_level": "list(debug|info|warning|error)?"
+    "log_level": "list(trace|debug|info|notice|warning|error|fatal)?"
   }
 }

--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -158,9 +158,9 @@ else
     username=$(bashio::services 'mysql' 'username')
     password=$(bashio::services 'mysql' 'password')
 
-    bashio::log.warning "Hedgedoc is using the Maria DB addon's database"
-    bashio::log.warning "Please ensure that addon is included in your backups"
-    bashio::log.warning "Uninstalling the Maria DB addon will also remove Hedgedoc's data"
+    bashio::log.notice "Hedgedoc is using the Maria DB addon's database"
+    bashio::log.notice "Please ensure that addon is included in your backups"
+    bashio::log.notice "Uninstalling the Maria DB addon will also remove Hedgedoc's data"
 
     if bashio::config.true 'reset_database'; then
         bashio::log.warning 'Resetting database...'

--- a/hedgedoc/rootfs/etc/services.d/hedgedoc/run
+++ b/hedgedoc/rootfs/etc/services.d/hedgedoc/run
@@ -79,10 +79,13 @@ fi
 
 # Set log level
 case "$(bashio::config 'log_level')" in \
-    debug)	    log_level='debug' && export DEBUG=true ;; \
-    error)      log_level='error' ;; \
-    warning)	log_level='warn' ;; \
-    *)		    log_level='info' ;; \
+    trace)      ;& \
+    debug)      log_level='debug' && export DEBUG=true ;; \
+    notice)     ;& \
+    warning)    log_level='warn' ;; \
+    error)      ;& \
+    fatal)      log_level='error' ;; \
+    *)          log_level='info' ;; \
 esac;
 export CMD_LOGLEVEL="${log_level}"
 bashio::log.info "Hedgedoc log level set to ${log_level}"


### PR DESCRIPTION
Enable `trace`, `notice` and `fatal` and map to their closest HedgeDoc equivalents for logging. Also log MariaDB messages at `notice` level as that is more appropriate.