### PR TITLE
User can set protocolSSL separate from useSSL

### DIFF
--- a/hedgedoc/DOCS.md
+++ b/hedgedoc/DOCS.md
@@ -89,9 +89,8 @@ will not work. Check the [HedgeDoc docs][hedgedoc-docs] for more info.
 
 ### Option: `access.use_ssl`
 
-If users will use SSL to access HedgeDoc. If `ssl` is `true` then this option is
-also `true` and cannot be set separately. Otherwise defaults to `false`. Ignored
-if `access.domain` is omitted.
+If users will use SSL to access HedgeDoc. Defaults to `false`. Ignored if `access.domain`
+is omitted.
 
 ### Option: `access.add_port`
 

--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -65,12 +65,6 @@ if bashio::config.true 'ssl'; then
         bashio::exit.nok
     fi
 
-    # If ssl is true then use_ssl is automatically true
-    if bashio::config.exists 'access.use_ssl'; then
-        bashio::log.warning "Invalid option: 'access.use_ssl' can only be set when 'ssl' is disabled. Removing..."
-        bashio::addon.option 'access.use_ssl'
-    fi
-
     bashio::log.info 'Setting up SSL...'
     jq \
         --arg cert "/ssl/$(bashio::config 'certfile')" \


### PR DESCRIPTION
Apparently setting `useSSL` to `true` does not automatically turn on `protocolUseSSL` as the documentation implies. Therefore allowing users to set it separately.