### PR TITLE
Use not is empty instead of exists for UI

### DIFF
--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -19,7 +19,7 @@ bashio::log.debug 'Validate access config and look for suggestions.'
 bashio::config.suggest 'access.session_secret' 'All sessions will be invalidated each time the add-on restarts.'
 
 bashio::config.suggest 'access.domain' 'A number of HedgeDoc features do not work without it.'
-if ! bashio::config.exists 'access.domain'; then
+if bashio::config.is_empty 'access.domain'; then
     if bashio::config.exists 'access.use_ssl'; then
         bashio::log.warning "Invalid option: 'access.use_ssl' set without an 'access.domain'. Removing..."
         bashio::addon.option 'access.use_ssl'
@@ -106,7 +106,7 @@ done
 # --- SET UP DATABASE ---
 bashio::log.debug 'Setting up database.'
 # Use user-provided remote db
-if bashio::config.exists 'remote_mysql_host'; then
+if ! bashio::config.is_empty 'remote_mysql_host'; then
     bashio::config.require 'remote_mysql_database' "'remote_mysql_host' is specified"
     bashio::config.require 'remote_mysql_username' "'remote_mysql_host' is specified"
     bashio::config.require 'remote_mysql_password' "'remote_mysql_host' is specified"

--- a/hedgedoc/rootfs/etc/services.d/hedgedoc/run
+++ b/hedgedoc/rootfs/etc/services.d/hedgedoc/run
@@ -32,7 +32,7 @@ for var in $(bashio::config 'env_vars|keys'); do
 done
 
 # Set DB URL
-if bashio::config.exists 'remote_mysql_host'; then
+if ! bashio::config.is_empty 'remote_mysql_host'; then
     host=$(bashio::config 'remote_mysql_host')
     port=$(bashio::config 'remote_mysql_port')
     username=$(bashio::config 'remote_mysql_username')
@@ -55,7 +55,7 @@ export "CMD_DB_URL=mysql://${username}:${password}@${host}:${port}/${database}"
 if bashio::config.true 'access.use_ssl'; then
     export CMD_PROTOCOL_USESSL=true
 fi
-if bashio::config.exists 'access.domain'; then
+if ! bashio::config.is_empty 'access.domain'; then
     export "CMD_DOMAIN=$(bashio::config 'access.domain')"
 fi
 if bashio::config.true 'access.add_port'; then
@@ -63,7 +63,7 @@ if bashio::config.true 'access.add_port'; then
 fi
 
 # Set session configs if present
-if bashio::config.exists 'access.session_secret'; then
+if ! bashio::config.is_empty 'access.session_secret'; then
     export "CMD_SESSION_SECRET=$(bashio::config 'access.session_secret')"
 fi
 if bashio::config.exists 'access.session_days'; then


### PR DESCRIPTION
For all optional string-type configs, use not `is_empty` as the check to determine if they are in effect instead of `exists` because the UI editor will only let you blank out string configs, not remove them. Although UI editor isn't usable with this addon currently, might as well prepare for it.