### PR TITLE
Use dsaparam option to generate dhparam for ssl

### DIFF
--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -70,7 +70,7 @@ if bashio::config.true 'ssl'; then
         bashio::log.notice "This will take some time but it will only happen once."
         bashio::log.notice
 
-        openssl dhparam -out "${DHPARAMS_FILE}" 4096 > /dev/null
+        openssl dhparam -dsaparam -out "${DHPARAMS_FILE}" 4096 2> /dev/null
     fi
 
     # permissions


### PR DESCRIPTION
Generating a 4096 bit dhparam takes too long on a pi-like device, use `dsaparam` like the NGinx add-on does.