### PR TITLE
AppArmor - add RO access to ca-certificates folder

### DIFF
--- a/hedgedoc/apparmor.txt
+++ b/hedgedoc/apparmor.txt
@@ -105,6 +105,7 @@ profile hedgedoc flags=(attach_disconnected,mediate_deleted) {
     @{do_etc_ro}/hosts                    r,
     @{do_etc_ro}/resolv.conf              r,
     @{do_etc_ro}/ssl/openssl.cnf          r,
+    @{do_usr}/share/ca-certificates/**    r,
     @{PROC}/*/stat                        r,
     @{PROC}/loadavg                       r,
     @{sys}/fs/cgroup/memory/memory.limit_in_bytes   r,


### PR DESCRIPTION
Oauth login flows require read access to `/usr/share/ca-certificates/**` to function.