### PR TITLE
Missed a closing underscore in docs

### DIFF
--- a/hedgedoc/DOCS.md
+++ b/hedgedoc/DOCS.md
@@ -49,7 +49,7 @@ log_level: info
 env_vars: []
 ```
 
-**Note**: \_This is just an example, don't copy and paste it! Create your own!
+**Note**: _This is just an example, don't copy and paste it! Create your own!_
 
 ### Option: `ssl`
 


### PR DESCRIPTION
Closing underscore missing in the docs so the character was just showing up instead of making it italics.