### PR TITLE
Bump addons base from `9.1.7` to `9.2.0`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -1,11 +1,11 @@
 # https://github.com/hassio-addons/addon-base/releases
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.7
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://quay.io/repository/hedgedoc/hedgedoc
 FROM quay.io/hedgedoc/hedgedoc:1.7.2-alpine AS build
 
-# hadolint ignore=DL3006
-FROM ${BUILD_FROM}
+# https://github.com/hassio-addons/addon-base/releases
+FROM ${BUILD_FROM}:9.2.0
 # https://github.com/hedgedoc/hedgedoc/releases
 ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.7.2
 

--- a/hedgedoc/build.json
+++ b/hedgedoc/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.7",
-    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.7",
-    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.7",
-    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.7",
-    "i386": "ghcr.io/hassio-addons/base/i386:9.1.7"
+    "amd64": "ghcr.io/hassio-addons/base/amd64",
+    "armv7": "ghcr.io/hassio-addons/base/armv7",
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64",
+    "armhf": "ghcr.io/hassio-addons/base/armhf",
+    "i386": "ghcr.io/hassio-addons/base/i386"
   }
 }


### PR DESCRIPTION
Bumps hassio-addons/addon-base image from `9.1.7` to [9.2.0](https://github.com/hassio-addons/addon-base/releases/tag/v9.2.0)