### PR TITLE
Add docker to dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+  - package-ecosystem: docker
+    directory: "/hedgedoc"
+    schedule:
+      interval: daily

--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -1,4 +1,3 @@
-# https://github.com/hassio-addons/addon-base/releases
 ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://quay.io/repository/hedgedoc/hedgedoc


### PR DESCRIPTION
Let dependabot keep the dockerfile up to date (well at least the parts it understands)