### PR TITLE
Update to HedgeDoc 1.8.0 and remove sequelizerc

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -1,12 +1,12 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://quay.io/repository/hedgedoc/hedgedoc
-FROM quay.io/hedgedoc/hedgedoc:1.7.2-alpine AS build
+FROM quay.io/hedgedoc/hedgedoc:1.8.0-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
 FROM ${BUILD_FROM}:9.2.0
 # https://github.com/hedgedoc/hedgedoc/releases
-ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.7.2
+ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.0
 
 RUN set -eux; \
     apk update; \

--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -180,6 +180,3 @@ else
     echo "CREATE DATABASE IF NOT EXISTS \`${DATABASE}\`;" \
         | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
 fi
-
-# Use our DB settings files
-cp "${CONFIG_DIR}/sequelizerc" "${HEDGEDOC_DIR}/.sequelizerc"

--- a/hedgedoc/rootfs/etc/hedgedoc/sequelizerc
+++ b/hedgedoc/rootfs/etc/hedgedoc/sequelizerc
@@ -1,8 +1,0 @@
-var path = require('path');
-
-module.exports = {
-    'config':          path.resolve('config.json'),
-    'migrations-path': path.resolve('lib', 'migrations'),
-    'models-path':     path.resolve('lib', 'models'),
-    'url':             process.env.CMD_DB_URL
-}


### PR DESCRIPTION
Update from HedgeDoc v1.7.2 to [1.8.0](https://github.com/hedgedoc/hedgedoc/releases/tag/1.8.0). This release does fix a couple security issues so recommend to update as soon as possible. In addition have removed custom `.sequelizerc` as this release makes it unnecessary.