### PR TITLE
Stop doing db migrations prior to startup

### DIFF
--- a/hedgedoc/rootfs/etc/services.d/hedgedoc/run
+++ b/hedgedoc/rootfs/etc/services.d/hedgedoc/run
@@ -103,10 +103,6 @@ export "CMD_PORT=${HTTP_PORT}"
 
 cd /opt/hedgedoc || :
 
-# run database migrations
-bashio::log.debug "Running database migrations if necessary..."
-s6-setuidgid abc ./node_modules/sequelize-cli/lib/sequelize db:migrate || exit
-
 if bashio::var.equals "${log_level}" "debug"; then
     bashio::log.debug
     bashio::log.debug "Printing all CMD_* env vars overriding config file options"


### PR DESCRIPTION
1.8.0 takes care of db migrations for you on app startup, continuing to try to do them yourself before startup seems to cause an error. Let HedgeDoc do it.