### PR TITLE
Set `cspupgradeInsecureRequests` to `false` in settings

### DIFF
--- a/hedgedoc/rootfs/etc/hedgedoc/config.json
+++ b/hedgedoc/rootfs/etc/hedgedoc/config.json
@@ -1,3 +1,11 @@
 {
-  "production": {}
+  "production": {
+    "csp": {
+      "enable": true,
+      "directives": {
+        "frameAncestors": "'self'"
+      },
+      "upgradeInsecureRequests": false
+    }
+  }
 }

--- a/hedgedoc/rootfs/etc/hedgedoc/config.json
+++ b/hedgedoc/rootfs/etc/hedgedoc/config.json
@@ -1,10 +1,6 @@
 {
   "production": {
     "csp": {
-      "enable": true,
-      "directives": {
-        "frameAncestors": "'self'"
-      },
       "upgradeInsecureRequests": false
     }
   }


### PR DESCRIPTION
In 1.8.0 there seems to be an issue which prevents `csp.upgradeInsecureRequests` from being turned on, it just breaks if you try. Since the [description of this header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/upgrade-insecure-requests) says "This directive is intended for web sites with large numbers of insecure legacy URLs that need to be rewritten." That doesn't really seem appropriate to be on by default anyway so defaulting it to `false` doesn't seem like a bad idea anyway, may give a setting for it in the future once it works in HedgeDoc again.