### PR TITLE
Add option to set csp directives

### DIFF
--- a/hedgedoc/DOCS.md
+++ b/hedgedoc/DOCS.md
@@ -43,10 +43,21 @@ Example add-on configuration:
 ssl: true
 certfile: fullchain.pem
 keyfile: privkey.pem
-session_secret: changeme
-session_days: 30
+access:
+  domain: homeassistant.local
+  add_port: true
+  session_secret: changeme
+  session_days: 30
+csp:
+  directives:
+    - name: frameAncestors
+      value: "'self'"
+env_vars:
+  - name: CMD_HSTS_ENABLE
+    value: "true"
+  - name: CMD_HSTS_PRELOAD
+    value: "false"
 log_level: info
-env_vars: []
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -107,6 +118,13 @@ Number of days before users have to log in again.
 Enable/disable the ability to sign up with an email. Defaults to `true`. Set to
 `false` if you want to limit who can login to a fixed set of users. Or if you want
 to only allow an [alternate login method][hedgedoc-docs-login].
+
+### Option: `csp.directives`
+
+Set directives for [helmet][helmet-docs] to use to configure the content security
+policy. HedgeDoc itself also sets a number of defaults here so your directives
+will be merged with theirs. See [their documentation][hedgedoc-docs-web-sec] for
+more information.
 
 ### Option: `remote_mysql_host`
 
@@ -241,6 +259,8 @@ SOFTWARE.
 [hedgedoc]: https://hedgedoc.org/
 [hedgedoc-docs]: https://docs.hedgedoc.org/
 [hedgedoc-docs-login]: https://docs.hedgedoc.org/configuration/#login-methods
+[hedgedoc-docs-web-sec]: https://docs.hedgedoc.org/configuration/#web-security-aspects
+[helmet-docs]: https://helmetjs.github.io/
 [hsts-preload]: https://hstspreload.org/
 [issue]: https://github.com/mdegat01/addon-hedgedoc/issues
 [mdegat01]: https://github.com/mdegat01

--- a/hedgedoc/config.json
+++ b/hedgedoc/config.json
@@ -23,6 +23,9 @@
       "session_secret": null,
       "session_days": 30
     },
+    "csp": {
+      "directives": []
+    },
     "log_level": "info",
     "env_vars": []
   },
@@ -38,6 +41,14 @@
       "session_secret": "password?",
       "session_days": "int(1,)?",
       "allow_email_registration": "bool?"
+    },
+    "csp": {
+      "directives": [
+        {
+          "name": "str",
+          "value": "str"
+        }
+      ]
     },
     "remote_mysql_host": "str?",
     "remote_mysql_port": "port?",

--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -2,17 +2,12 @@
 # shellcheck shell=bash
 # ==============================================================================
 # Home Assistant Add-on: Hedgedoc
-# This validates config, creates the database and sets up app files/folders
+# This validates config and sets up app files/folders
 # ==============================================================================
-readonly DATABASE=hedgedoc
 readonly CONFIG_DIR=/etc/hedgedoc
 readonly DATA_DIR=/data/hedgedoc
 readonly HEDGEDOC_DIR=/opt/hedgedoc
 readonly DHPARAMS_FILE=/data/dhparams.pem
-declare host
-declare port
-declare username
-declare password
 declare http_port
 declare domain
 
@@ -81,10 +76,25 @@ if bashio::config.true 'ssl'; then
         --arg cert "/ssl/$(bashio::config 'certfile')" \
         --arg key "/ssl/$(bashio::config 'keyfile')" \
         --arg dhp "${DHPARAMS_FILE}" \
-        '. * {production: (.production * {useSSL:true, sslCertPath:$cert, sslKeyPath:$key, dhParamPath:$dhp})}' \
+        '.production*={useSSL:true, sslCertPath:$cert, sslKeyPath:$key, dhParamPath:$dhp}' \
         "${CONFIG_DIR}/config.json" > /tmp/config.json \
     && mv /tmp/config.json "${CONFIG_DIR}/config.json"
 fi
+
+
+# --- CSP OPTIONS ---
+bashio::log.debug 'Setting up CSP options...'
+for var in $(bashio::config 'csp.directives|keys'); do
+    name=$(bashio::config "csp.directives[${var}].name")
+    value=$(bashio::config "csp.directives[${var}].value")
+    bashio::log.info "Adding CSP directive ${name} with ${value}"
+    jq \
+        --arg name "${name}" \
+        --arg value "${value}" \
+        '.production.csp.directives[$name]|=$value' \
+        "${CONFIG_DIR}/config.json" > /tmp/config.json \
+    && mv /tmp/config.json "${CONFIG_DIR}/config.json"
+done
 
 
 # --- SYMLINKS IN HEDGEDOC DIRECTORY ---
@@ -112,71 +122,3 @@ for i in "${symlinks[@]}"; do
         ln -s "${DATA_DIR}/$(basename "$i")" "$i"
     fi
 done
-
-
-# --- SET UP DATABASE ---
-bashio::log.debug 'Setting up database.'
-# Use user-provided remote db
-if ! bashio::config.is_empty 'remote_mysql_host'; then
-    bashio::config.require 'remote_mysql_database' "'remote_mysql_host' is specified"
-    bashio::config.require 'remote_mysql_username' "'remote_mysql_host' is specified"
-    bashio::config.require 'remote_mysql_password' "'remote_mysql_host' is specified"
-    bashio::config.require 'remote_mysql_port' "'remote_mysql_host' is specified"
-
-    host=$(bashio::config 'remote_mysql_host')
-    port=$(bashio::config 'remote_mysql_port')
-    bashio::log.info "Using remote database at ${host}:${port}"
-
-    # Wait until db is available.
-    connected=false
-    for _ in {1..30}; do
-        if nc -w1 "${host}" "${port}" > /dev/null 2>&1; then
-            connected=true
-            break
-        fi
-        sleep 1
-    done
-
-    if [ $connected = false ]; then
-        bashio::log.fatal
-        bashio::log.fatal "Cannot connect to remote database at ${host}:${port}!"
-        bashio::log.fatal "Exiting after retrying for 30 seconds."
-        bashio::log.fatal
-        bashio::log.fatal "Please ensure the config is set correctly and"
-        bashio::log.fatal "the database is available at the specified host and port."
-        bashio::log.fatal
-        bashio::exit.nok
-    fi
-
-# Use mysql service provided by supervisor
-else
-    if ! bashio::services.available 'mysql'; then
-        bashio::log.fatal
-        bashio::log.fatal 'MariaDB addon not available and no alternate database supplied'
-        bashio::log.fatal 'Ensure MariaDB addon is available or provide an alternate database'
-        bashio::log.fatal
-        bashio::exit.nok
-    fi
-
-    host=$(bashio::services 'mysql' 'host')
-    port=$(bashio::services 'mysql' 'port')
-    username=$(bashio::services 'mysql' 'username')
-    password=$(bashio::services 'mysql' 'password')
-
-    bashio::log.notice "Hedgedoc is using the Maria DB addon's database"
-    bashio::log.notice "Please ensure that addon is included in your backups"
-    bashio::log.notice "Uninstalling the Maria DB addon will also remove Hedgedoc's data"
-
-    if bashio::config.true 'reset_database'; then
-        bashio::log.warning 'Resetting database...'
-        echo "DROP DATABASE IF EXISTS \`${DATABASE}\`;" \
-            | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
-
-        # Remove `reset_database` option
-        bashio::addon.option 'reset_database'
-    fi
-
-    # Create database if it doesn't exist
-    echo "CREATE DATABASE IF NOT EXISTS \`${DATABASE}\`;" \
-        | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
-fi

--- a/hedgedoc/rootfs/etc/cont-init.d/40-mysql.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/40-mysql.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Home Assistant Add-on: Hedgedoc
+# This validates and sets up the database
+# ==============================================================================
+readonly DATABASE=hedgedoc
+declare host
+declare port
+declare username
+declare password
+
+bashio::log.debug 'Setting up database.'
+# Use user-provided remote db
+if ! bashio::config.is_empty 'remote_mysql_host'; then
+    bashio::config.require 'remote_mysql_database' "'remote_mysql_host' is specified"
+    bashio::config.require 'remote_mysql_username' "'remote_mysql_host' is specified"
+    bashio::config.require 'remote_mysql_password' "'remote_mysql_host' is specified"
+    bashio::config.require 'remote_mysql_port' "'remote_mysql_host' is specified"
+
+    host=$(bashio::config 'remote_mysql_host')
+    port=$(bashio::config 'remote_mysql_port')
+    bashio::log.info "Using remote database at ${host}:${port}"
+
+    # Wait until db is available.
+    connected=false
+    for _ in {1..30}; do
+        if nc -w1 "${host}" "${port}" > /dev/null 2>&1; then
+            connected=true
+            break
+        fi
+        sleep 1
+    done
+
+    if [ $connected = false ]; then
+        bashio::log.fatal
+        bashio::log.fatal "Cannot connect to remote database at ${host}:${port}!"
+        bashio::log.fatal "Exiting after retrying for 30 seconds."
+        bashio::log.fatal
+        bashio::log.fatal "Please ensure the config is set correctly and"
+        bashio::log.fatal "the database is available at the specified host and port."
+        bashio::log.fatal
+        bashio::exit.nok
+    fi
+
+# Use mysql service provided by supervisor
+else
+    if ! bashio::services.available 'mysql'; then
+        bashio::log.fatal
+        bashio::log.fatal 'MariaDB addon not available and no alternate database supplied'
+        bashio::log.fatal 'Ensure MariaDB addon is available or provide an alternate database'
+        bashio::log.fatal
+        bashio::exit.nok
+    fi
+
+    host=$(bashio::services 'mysql' 'host')
+    port=$(bashio::services 'mysql' 'port')
+    username=$(bashio::services 'mysql' 'username')
+    password=$(bashio::services 'mysql' 'password')
+
+    bashio::log.notice "Hedgedoc is using the Maria DB addon's database"
+    bashio::log.notice "Please ensure that addon is included in your backups"
+    bashio::log.notice "Uninstalling the Maria DB addon will also remove Hedgedoc's data"
+
+    if bashio::config.true 'reset_database'; then
+        bashio::log.warning 'Resetting database...'
+        echo "DROP DATABASE IF EXISTS \`${DATABASE}\`;" \
+            | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
+
+        # Remove `reset_database` option
+        bashio::addon.option 'reset_database'
+    fi
+
+    # Create database if it doesn't exist
+    echo "CREATE DATABASE IF NOT EXISTS \`${DATABASE}\`;" \
+        | mysql -h "${host}" -P "${port}" -u "${username}" -p"${password}"
+fi


### PR DESCRIPTION
HedgeDoc uses a nice middleware tool called [helmet](https://helmetjs.github.io/) and has an easy way to pass directives to it in the configuration. Since we are changing the CSP stuff seems good to expose this option for users.