### PR TITLE
Move csp directives config to root level

### DIFF
--- a/hedgedoc/DOCS.md
+++ b/hedgedoc/DOCS.md
@@ -119,7 +119,7 @@ Enable/disable the ability to sign up with an email. Defaults to `true`. Set to
 `false` if you want to limit who can login to a fixed set of users. Or if you want
 to only allow an [alternate login method][hedgedoc-docs-login].
 
-### Option: `csp.directives`
+### Option: `csp_directives`
 
 Set directives for [helmet][helmet-docs] to use to configure the content security
 policy. HedgeDoc itself also sets a number of defaults here so your directives

--- a/hedgedoc/DOCS.md
+++ b/hedgedoc/DOCS.md
@@ -48,10 +48,9 @@ access:
   add_port: true
   session_secret: changeme
   session_days: 30
-csp:
-  directives:
-    - name: frameAncestors
-      value: "'self'"
+csp_directives:
+  - name: frameAncestors
+    value: "'self'"
 env_vars:
   - name: CMD_HSTS_ENABLE
     value: "true"

--- a/hedgedoc/config.json
+++ b/hedgedoc/config.json
@@ -23,9 +23,7 @@
       "session_secret": null,
       "session_days": 30
     },
-    "csp": {
-      "directives": []
-    },
+    "csp_directives": [],
     "log_level": "info",
     "env_vars": []
   },
@@ -42,14 +40,12 @@
       "session_days": "int(1,)?",
       "allow_email_registration": "bool?"
     },
-    "csp": {
-      "directives": [
-        {
-          "name": "str",
-          "value": "str"
-        }
-      ]
-    },
+    "csp_directives": [
+      {
+        "name": "str",
+        "value": "str"
+      }
+    ],
     "remote_mysql_host": "str?",
     "remote_mysql_port": "port?",
     "remote_mysql_username": "str?",

--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -84,9 +84,9 @@ fi
 
 # --- CSP OPTIONS ---
 bashio::log.debug 'Setting up CSP options...'
-for var in $(bashio::config 'csp.directives|keys'); do
-    name=$(bashio::config "csp.directives[${var}].name")
-    value=$(bashio::config "csp.directives[${var}].value")
+for var in $(bashio::config 'csp_directives|keys'); do
+    name=$(bashio::config "csp_directives[${var}].name")
+    value=$(bashio::config "csp_directives[${var}].value")
     bashio::log.info "Adding CSP directive ${name} with ${value}"
     jq \
         --arg name "${name}" \


### PR DESCRIPTION
It appears HA addons don't like nested arrays of objects. Moving the csp directives setting to the root level to conform to these requirements.