### PR TITLE
Don't copy OOTB views and notes from public

### DIFF
--- a/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
+++ b/hedgedoc/rootfs/etc/cont-init.d/30-config.sh
@@ -105,10 +105,7 @@ ln -s "${CONFIG_DIR}/config.json" "${HEDGEDOC_DIR}/config.json"
 
 # Public folders in data volume and symlink
 symlinks=( \
-"${HEDGEDOC_DIR}/public/docs" \
 "${HEDGEDOC_DIR}/public/uploads" \
-"${HEDGEDOC_DIR}/public/views" \
-"${HEDGEDOC_DIR}/public/default.md"
 )
 for i in "${symlinks[@]}"; do
     # if config file is present just remove container one and symlink


### PR DESCRIPTION
Storing the views and notes from the public folder doesn't really serve any benefit. Users aren't going to go into the addon to update it and HedgeDoc clearly expects to be able to update it every release (since views from 1.7.2 broke on update to 1.8.0) Only symlink `/public/uploads` since that does have to be stored with add-on, let hedgedoc manage everything else.