### PR TITLE
Update to HedgeDoc to `1.8.1`

### DIFF
--- a/hedgedoc/DOCS.md
+++ b/hedgedoc/DOCS.md
@@ -88,6 +88,9 @@ will not work. Check the [HedgeDoc docs][hedgedoc-docs] for more info.
 If users will use SSL to access HedgeDoc. Defaults to `false`. Ignored if `access.domain`
 is omitted.
 
+**Note**: _If `ssl` is `true` then this option becomes `true` as well and cannot
+be set to `false`._
+
 ### Option: `access.add_port`
 
 If users will include the port in the URL when accessing HedgeDoc. Defaults to

--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -1,12 +1,12 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://quay.io/repository/hedgedoc/hedgedoc
-FROM quay.io/hedgedoc/hedgedoc:1.8.0-alpine AS build
+FROM quay.io/hedgedoc/hedgedoc:1.8.1-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
 FROM ${BUILD_FROM}:9.2.0
 # https://github.com/hedgedoc/hedgedoc/releases
-ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.0
+ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.1
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update HedgeDoc from `1.8.0` to [1.8.1](https://github.com/hedgedoc/hedgedoc/releases/tag/1.8.1). Fixes https://github.com/hedgedoc/hedgedoc/issues/1221.

Also note that now `protocolUseSSL` becomes `true` when `useSSL` is `true`. Which makes sense, that'll become another very small breaking change though (`access.use_ssl` automatically becomes `true` when `ssl` is `true`). Should've just done that from the beginning can't remember why I didn't 🤦 