### PR TITLE
Update HedgeDoc to `1.8.2`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -1,12 +1,12 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://quay.io/repository/hedgedoc/hedgedoc
-FROM quay.io/hedgedoc/hedgedoc:1.8.1-alpine AS build
+FROM quay.io/hedgedoc/hedgedoc:1.8.2-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
 FROM ${BUILD_FROM}:9.2.0
 # https://github.com/hedgedoc/hedgedoc/releases
-ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.1
+ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.2
 
 RUN set -eux; \
     apk update; \


### PR DESCRIPTION
Update HedgeDoc from `1.8.1` to [1.8.2](https://github.com/hedgedoc/hedgedoc/releases/tag/1.8.2). Fixes [CVE-2021-29503](https://github.com/hedgedoc/hedgedoc/security/advisories/GHSA-gjg7-4j2h-94fq) so should update quickly.