### PR TITLE
Bump addon base to `10.0.0`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -14,8 +14,8 @@ RUN set -eux; \
         ca-certificates=20191127-r5 \
         netcat-openbsd=1.130-r2 \
         mariadb-client=10.5.9-r0 \
-        nodejs=14.16.1-r1 \
-        npm=14.16.1-r1 \
+        nodejs=14.17.1-r0 \
+        npm=7.17.0-r0 \
         openssl=1.1.1k-r0 \
         ; \
     node --version; \

--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 FROM quay.io/hedgedoc/hedgedoc:1.8.2-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:9.2.2
+FROM ${BUILD_FROM}:10.0.0
 # https://github.com/hedgedoc/hedgedoc/releases
 ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.2
 


### PR DESCRIPTION
Bump addon base from `9.2.2` to [10.0.0](https://github.com/hassio-addons/addon-base/releases/tag/v10.0.0). Also requires updates to following packages:
- nodejs to `14.17.1-r0`
- npm to `7.17.0-r0`