### PR TITLE
Update to HedgeDoc to `1.9.0`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 
 # https://quay.io/repository/hedgedoc/hedgedoc
-FROM quay.io/hedgedoc/hedgedoc:1.8.2-alpine AS build
+FROM quay.io/hedgedoc/hedgedoc:1.9.0-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
 FROM ${BUILD_FROM}:10.0.2


### PR DESCRIPTION
Update from HedgeDoc `1.8.2` to [1.9.0](https://github.com/hedgedoc/hedgedoc/releases/tag/1.9.0)