### PR TITLE
Bump addon base to `10.2.1`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 FROM quay.io/hedgedoc/hedgedoc:1.9.0-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:10.2.0
+FROM ${BUILD_FROM}:10.2.1
 # https://github.com/hedgedoc/hedgedoc/releases
 ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.2
 


### PR DESCRIPTION
Bump addon base from `10.2.0` to [10.2.1](https://github.com/hassio-addons/addon-base/releases/tag/v10.2.1)