### PR TITLE
Bump addon base to `11.0.0`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -4,19 +4,19 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 FROM quay.io/hedgedoc/hedgedoc:1.9.0-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:10.2.3
+FROM ${BUILD_FROM}:11.0.0
 # https://github.com/hedgedoc/hedgedoc/releases
 ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.2
 
 RUN set -eux; \
     apk update; \
     apk add --no-cache \
-        ca-certificates=20191127-r5 \
-        netcat-openbsd=1.130-r2 \
-        mariadb-client=10.5.13-r0 \
-        nodejs=14.18.1-r0 \
-        npm=7.17.0-r0 \
-        openssl=1.1.1l-r0 \
+        ca-certificates=20191127-r7 \
+        netcat-openbsd=1.130-r3 \
+        mariadb-client=10.6.4-r1 \
+        nodejs=16.13.0-r0 \
+        npm=8.1.3-r0 \
+        openssl=1.1.1l-r7 \
         ; \
     node --version; \
     update-ca-certificates; \


### PR DESCRIPTION
Bump addon base from `10.2.3` to [11.0.0](https://github.com/hassio-addons/addon-base/releases/tag/v11.0.0).

Additionally bump the following packages to latest for alpine 3.15:

- ca-certificates: `20191127-r5` -> `20191127-r7`
- netcat-openbsd: `1.130-r2` -> `1.130-r3`
- mariadb-client: `10.5.13-r0` -> `10.6.4-r1`
- nodejs: `14.18.1-r0` -> `16.13.0-r0`
- npm: `7.17.0-r0` -> `8.1.3-r0`
- openssl: `1.1.1l-r0` -> `1.1.1l-r7`
