### PR TITLE
Remove `GITHUB_TOKEN` input from all workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,5 +18,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/addon-ci.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,4 +18,3 @@ jobs:
     secrets:
       DISPATCH_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
       GHCR_TOKEN: ${{ secrets.GHCR_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/labels.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/lock.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -13,5 +13,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/pr-labels.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/release-drafter.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,5 +10,3 @@ on:
 jobs:
   workflows:
     uses: mdegat01/addon-workflows/.github/workflows/stale.yaml@main
-    secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux; \
     apk add --no-cache \
         ca-certificates=20191127-r7 \
         netcat-openbsd=1.130-r3 \
-        mariadb-client=10.6.4-r1 \
+        mariadb-client=10.6.4-r2 \
         nodejs=16.13.1-r0 \
         npm=8.1.3-r0 \
         openssl=1.1.1l-r7 \


### PR DESCRIPTION
Remove unnecessary `GITHUB_TOKEN` input from all workflows as it breaks things. Also bump mariadb-client to latest (`10.6.4-r1` -> `10.6.4-r2`)