### PR TITLE
Add access to ssl cnf file and other used files

### DIFF
--- a/hedgedoc/apparmor.txt
+++ b/hedgedoc/apparmor.txt
@@ -40,7 +40,7 @@ profile hedgedoc flags=(attach_disconnected,mediate_deleted) {
   @{do_run}/**                                    rwk,
   /dev/tty                                        rw,
   @{do_usr}/lib/locale/{,**}                      r,
-  @{do_etc}/ssl/openssl.cnf                       r,
+  @{do_etc}/ssl{,1.1}/openssl.cnf                 r,
   @{do_etc}/{group,hosts,passwd,resolv.conf}      r,
   /dev/null                                       k,
 
@@ -92,16 +92,16 @@ profile hedgedoc flags=(attach_disconnected,mediate_deleted) {
     /ssl/**                                         r,
 
     # Executables
+    /bin/busybox                                    rmix,
     /opt/hedgedoc/bin/**                            rix,
     /usr/bin/node                                   rix,
 
     # Runtime usage
     owner /tmp/**                                   rw,
-    /bin/busybox                                    rm,
     @{do_etc}/{hosts,resolv.conf}                   r,
-    @{do_etc}/ssl/openssl.cnf                       r,
+    @{do_etc}/ssl{,1.1}/openssl.cnf                 r,
     @{do_usr}/share/ca-certificates/**              r,
-    @{PROC}/[1-9]*/stat                             r,
+    @{PROC}/[1-9]*/{limits,stat}                    r,
     @{PROC}/loadavg                                 r,
     @{sys}/fs/cgroup/memory/memory.limit_in_bytes   r,
     /opt/hedgedoc/node_modules/*/prebuilds/**.node  rm,


### PR DESCRIPTION
HedgeDoc seems to need access to a second ssl cnf file and a few others showing up in the audit log. Adding that access.