### PR TITLE
Bump hassio-addons/base to `11.1.2`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 FROM quay.io/hedgedoc/hedgedoc:1.9.3-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:11.0.1
+FROM ${BUILD_FROM}:11.1.2
 # https://github.com/hedgedoc/hedgedoc/releases
 ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.2
 

--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -4,7 +4,8 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64
 FROM quay.io/hedgedoc/hedgedoc:1.9.3-alpine AS build
 
 # https://github.com/hassio-addons/addon-base/releases
-FROM ${BUILD_FROM}:11.1.2
+# hadolint ignore=DL3006
+FROM ${BUILD_FROM}
 # https://github.com/hedgedoc/hedgedoc/releases
 ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.2
 

--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -11,7 +11,7 @@ ENV CMD_SOURCE_URL https://github.com/hedgedoc/hedgedoc/tree/1.8.2
 RUN set -eux; \
     apk update; \
     apk add --no-cache \
-        ca-certificates=20191127-r7 \
+        ca-certificates=20211220-r0 \
         netcat-openbsd=1.130-r3 \
         mariadb-client=10.6.7-r0 \
         nodejs=16.14.2-r0 \

--- a/hedgedoc/build.yaml
+++ b/hedgedoc/build.yaml
@@ -1,7 +1,7 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/base/amd64
-  armv7: ghcr.io/hassio-addons/base/armv7
-  aarch64: ghcr.io/hassio-addons/base/aarch64
-  armhf: ghcr.io/hassio-addons/base/armhf
-  i386: ghcr.io/hassio-addons/base/i386
+  amd64: ghcr.io/hassio-addons/base/amd64:11.1.2
+  armv7: ghcr.io/hassio-addons/base/armv7:11.1.2
+  aarch64: ghcr.io/hassio-addons/base/aarch64:11.1.2
+  armhf: ghcr.io/hassio-addons/base/armhf:11.1.2
+  i386: ghcr.io/hassio-addons/base/i386:11.1.2


### PR DESCRIPTION
Bump hassio-addons/base from `11.0.1` to [11.1.2](https://github.com/hassio-addons/addon-base/releases/tag/v11.1.2)

Required package bumps:
- Bump ca-certificates from `20191127-r7` to `20211220-r0`
