### PR TITLE
Bump addon base to `12.2.3`

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -11,7 +11,7 @@ FROM ${BUILD_FROM}
 RUN set -eux; \
     apk update; \
     apk add --no-cache \
-        ca-certificates=20211220-r0 \
+        ca-certificates=20220614-r0 \
         netcat-openbsd=1.130-r3 \
         mariadb-client=10.6.9-r0 \
         nodejs=16.16.0-r0 \

--- a/hedgedoc/build.yaml
+++ b/hedgedoc/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/base:12.2.0
-  armv7: ghcr.io/hassio-addons/base:12.2.0
-  aarch64: ghcr.io/hassio-addons/base:12.2.0
-  armhf: ghcr.io/hassio-addons/base:12.2.0
-  i386: ghcr.io/hassio-addons/base:12.2.0
+  amd64: ghcr.io/hassio-addons/base:12.2.3
+  armv7: ghcr.io/hassio-addons/base:12.2.3
+  aarch64: ghcr.io/hassio-addons/base:12.2.3
+  armhf: ghcr.io/hassio-addons/base:12.2.3
+  i386: ghcr.io/hassio-addons/base:12.2.3
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com


### PR DESCRIPTION
Bump addon base from [12.2.0 to 12.2.3](https://github.com/hassio-addons/addon-base/compare/v12.2.0...v12.2.3)
