### PR TITLE
Bump addon base 12.2.7

### DIFF
--- a/hedgedoc/Dockerfile
+++ b/hedgedoc/Dockerfile
@@ -13,10 +13,10 @@ RUN set -eux; \
     apk add --no-cache \
         ca-certificates=20220614-r0 \
         netcat-openbsd=1.130-r3 \
-        mariadb-client=10.6.9-r0 \
-        nodejs=16.16.0-r0 \
+        mariadb-client=10.6.10-r0 \
+        nodejs=16.17.1-r0 \
         npm=8.10.0-r0 \
-        openssl=1.1.1q-r0 \
+        openssl=1.1.1s-r0 \
         ; \
     node --version; \
     update-ca-certificates; \

--- a/hedgedoc/build.yaml
+++ b/hedgedoc/build.yaml
@@ -1,10 +1,10 @@
 ---
 build_from:
-  amd64: ghcr.io/hassio-addons/base:12.2.3
-  armv7: ghcr.io/hassio-addons/base:12.2.3
-  aarch64: ghcr.io/hassio-addons/base:12.2.3
-  armhf: ghcr.io/hassio-addons/base:12.2.3
-  i386: ghcr.io/hassio-addons/base:12.2.3
+  amd64: ghcr.io/hassio-addons/base:12.2.7
+  armv7: ghcr.io/hassio-addons/base:12.2.7
+  aarch64: ghcr.io/hassio-addons/base:12.2.7
+  armhf: ghcr.io/hassio-addons/base:12.2.7
+  i386: ghcr.io/hassio-addons/base:12.2.7
 codenotary:
   base_image: codenotary@frenck.dev
   signer: codenotary@degatano.com


### PR DESCRIPTION
Bump addon base from `12.2.3` to [`12.2.7`](https://github.com/hassio-addons/addon-base/releases/tag/v12.2.7)

Also bump mariadb-client, nodejs and openssl